### PR TITLE
Correcting KeyError happening in quickstart notebook when "level" is scalar

### DIFF
--- a/src/score.py
+++ b/src/score.py
@@ -17,10 +17,13 @@ def load_test_data(path, var, years=slice('2017', '2018')):
     """
     ds = xr.open_mfdataset(f'{path}/*.nc', combine='by_coords')[var]
     if var in ['z', 't']:
-        try:
-            ds = ds.sel(level=500 if var == 'z' else 850).drop('level')
-        except ValueError:
-            ds = ds.drop('level')
+        if len(ds["level"].dims) > 0:
+            try:
+                ds = ds.sel(level=500 if var == 'z' else 850) .drop('level')
+            except ValueError:
+                ds = ds.drop('level')
+        else:
+            assert ds["level"].values == 500 if var == 'z' else ds["level"].values == 850
     return ds.sel(time=years)
 
 def compute_weighted_rmse(da_fc, da_true, mean_dims=xr.ALL_DIMS):

--- a/src/train_nn.py
+++ b/src/train_nn.py
@@ -44,6 +44,8 @@ class DataGenerator(keras.utils.Sequence):
                 data.append(ds[var].sel(level=levels))
             except ValueError:
                 data.append(ds[var].expand_dims({'level': generic_level}, 1))
+            except KeyError:
+                data.append(ds[var])
 
         self.data = xr.concat(data, 'level').transpose('time', 'lat', 'lon', 'level')
         self.mean = self.data.mean(('time', 'lat', 'lon')).compute() if mean is None else mean


### PR DESCRIPTION
Hello, when pulling the repo and running the `quickstart` notebook I got `KeyError` with the `load_test_data` and `DataGenerator` because `level` is a scalar value. I proposed a fix which I think will not impact other utilisation of this code (when `level` is not a scalar).